### PR TITLE
Check HorizontalPodAutoscalers for references to invalid Deployments

### DIFF
--- a/policy/deprek8.rego
+++ b/policy/deprek8.rego
@@ -43,6 +43,14 @@ _deny = msg {
   msg := sprintf("%s/%s: API extensions/v1beta1 for %s is no longer served by default, use apps/v1 instead.", [input.kind, input.metadata.name, input.kind])
 }
 
+# HorizontalPodAutoscaler scaleTargetRef references deployment resources under extensions/v1beta1 - use apps/v1 instead
+_deny = msg {
+  input.kind == "HorizontalPodAutoscaler"
+  input.spec.scaleTargetRef.kind == "Deployment"
+  input.spec.scaleTargetRef.apiVersion == "extensions/v1beta1"
+  msg := sprintf("%s/%s: scaleTargetRef references an invalid Deployment API version extensions/v1beta1, use apps/v1 instead.", [input.kind, input.metadata.name])
+}
+
 # networkpolicies resources under extensions/v1beta1 - use networking.k8s.io/v1 instead
 _deny = msg {
   input.apiVersion == "extensions/v1beta1"

--- a/policy/deprek8_tests.rego
+++ b/policy/deprek8_tests.rego
@@ -8,6 +8,24 @@ generate(version, kind) = obj {
   }
 }
 
+generateHpa(version, kind) = obj {
+  obj := {
+    "kind": "HorizontalPodAutoscaler",
+    "apiVersion": "autoscaling/v1",
+    "metadata": { "name": "foo" },
+    "spec": {
+      "maxReplicas": 12,
+      "minReplicas": 2,
+      "scaleTargetRef": {
+        "apiVersion": version,
+        "kind": kind,
+        "name": "demo"
+      },
+      "targetCPUUtilizationPercentage": 66
+    }
+  }
+}
+
 test_apps_v1beta1_is_deny {
   msg := deny with input as generate("apps/v1beta1", "foo")
   count(msg) == 1
@@ -40,6 +58,16 @@ test_deployments_extensions_v1beta1_is_deny {
 
 test_deployments_apps_v1_is_ok {
   msg := deny with input as generate("apps/v1", "Deployment")
+  count(msg) == 0
+}
+
+test_hpas_deployments_extensions_v1beta1_is_deny {
+  msg := deny with input as generateHpa("extensions/v1beta1", "Deployment")
+  count(msg) == 1
+}
+
+test_hpas_deployments_apps_v1_is_ok {
+  msg := deny with input as generateHpa("apps/v1", "Deployment")
   count(msg) == 0
 }
 
@@ -168,3 +196,4 @@ test_certificatereuests_v1alpha2_is_ok {
   msg := deny with input as generate("cert-manager.io/v1alpha2", "CertificateRequest")
   count(msg) == 0
 }
+


### PR DESCRIPTION
## Summary

Add a check for HPAs that reference Deployments with the older retired version "extensions/v1beta1". 

For example

```
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: example-hpa
  namespace: example-ns
spec:
  maxReplicas: 12
  minReplicas: 2
  scaleTargetRef:
    apiVersion: extensions/v1beta1
    kind: Deployment
    name: example-deploy
  targetCPUUtilizationPercentage: 66
```

## Tests

```
$ conftest verify

32 tests, 32 passed, 0 warnings, 0 failures, 0 exceptions
```